### PR TITLE
Work around for breaking changes in vim.treesitter.query.get_node_text

### DIFF
--- a/lua/logsitter/utils.lua
+++ b/lua/logsitter/utils.lua
@@ -7,7 +7,7 @@ end
 
 -- Makes node text fit on one line
 function M.node_text(node)
-	return table.concat(vim.treesitter.query.get_node_text(node), ", ")
+	return vim.treesitter.query.get_node_text(node, 0)
 end
 
 --- Return `true` if `str` starts with `start`


### PR DESCRIPTION
vim.treesitter.query.get_node_text takes an extra parameter (the buffer) and returns a string instead of a table of string as compared to ts_utils.get_node_text. See https://github.com/nvim-treesitter/nvim-treesitter/pull/2801#issuecomment-1101553040

This PR should fix #1 